### PR TITLE
Add Formula 1 2025 points tracker web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# formula1-futures
+# Formula 1 2025 Championship Points Tracker
+
+A lightweight single-page application that visualises a fictional take on the 2025 Formula 1 World Championship. Explore driver standings, cumulative points progression, race summaries and detailed results for every round in the season.
+
+## Features
+
+- 📊 **Driver standings** with wins, podiums, fastest laps and average finishing positions.
+- 📈 **Interactive Chart.js visualisation** of cumulative championship points with driver highlighting and all-driver toggle.
+- 🗺️ **Race timeline** cards summarising podiums, fastest laps and storyline for each Grand Prix.
+- 🧭 **Results explorer** table with race and driver filters to inspect how points were earned.
+- 📁 All data is included locally (`seasonData.js`) so the app works offline without an API.
+
+## Getting started
+
+1. Clone the repository and open the project folder.
+2. Serve the files with any static web server or open `index.html` directly in your browser.
+   - Example using Python: `python -m http.server 8000`
+   - Then browse to `http://localhost:8000` and navigate to `index.html`.
+
+## Project structure
+
+```
+├── app.js           # Application logic and interactive behaviour
+├── index.html       # Main page markup
+├── seasonData.js    # Driver and race data for the 2025 season (fictional)
+├── styles.css       # Styling and layout
+└── README.md
+```
+
+## Notes
+
+- The standings and results portray a narrative scenario for 2025 and are not based on real-world data.
+- The visuals are optimised for modern browsers. For the best experience view the app on a device wider than 768px.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,425 @@
+import { seasonData } from './seasonData.js';
+
+const driverColors = {
+  'Max Verstappen': '#1e41ff',
+  'Lando Norris': '#ff8700',
+  'Charles Leclerc': '#dc0000',
+  'Lewis Hamilton': '#00d2be',
+  'Oscar Piastri': '#f4d03f',
+  'Carlos Sainz': '#f05e23',
+  'George Russell': '#4cd0c8',
+  'Sergio Perez': '#3671c6',
+  'Fernando Alonso': '#006f62',
+  'Alex Albon': '#005aff',
+};
+
+const state = {
+  races: seasonData.races,
+  standings: seasonData.standings,
+  selectedDriver: seasonData.standings[0]?.driver || '',
+  showAllDrivers: true,
+  driverHistory: {},
+};
+
+let chart;
+let elements;
+
+const raceLabels = state.races.map((race) => `R${String(race.round).padStart(2, '0')}`);
+
+function init() {
+  elements = {
+    championCard: document.getElementById('championCard'),
+    standingsBody: document.querySelector('#standingsTable tbody'),
+    driverSelect: document.getElementById('driverSelect'),
+    showAllToggle: document.getElementById('showAllDrivers'),
+    chartCanvas: document.getElementById('progressChart'),
+    driverInsight: document.getElementById('driverInsight'),
+    timeline: document.getElementById('raceTimeline'),
+    raceFilter: document.getElementById('raceFilter'),
+    driverFilter: document.getElementById('driverFilter'),
+    resultsBody: document.querySelector('#resultsTable tbody'),
+  };
+
+  state.driverHistory = buildDriverHistory(state.races);
+
+  renderChampionCard();
+  renderStandings();
+  populateDriverSelect();
+  setupChart();
+  renderDriverInsight();
+  renderTimeline();
+  populateFilters();
+  updateResultsTable();
+
+  elements.driverSelect.addEventListener('change', (event) => {
+    state.selectedDriver = event.target.value;
+    renderStandings();
+    renderDriverInsight();
+    updateChartAppearance();
+  });
+
+  elements.showAllToggle.addEventListener('change', (event) => {
+    state.showAllDrivers = event.target.checked;
+    updateChartAppearance();
+  });
+
+  elements.raceFilter.addEventListener('change', updateResultsTable);
+  elements.driverFilter.addEventListener('change', updateResultsTable);
+
+  window.addEventListener('resize', () => chart?.resize());
+}
+
+document.addEventListener('DOMContentLoaded', init);
+
+function buildDriverHistory(races) {
+  const map = {};
+  races.forEach((race) => {
+    race.results.forEach((result) => {
+      if (!map[result.driver]) {
+        map[result.driver] = [];
+      }
+      map[result.driver].push({
+        round: race.round,
+        race: race.name,
+        date: race.date,
+        position: result.position,
+        points: result.points,
+        fastestLap: race.fastestLap.driver === result.driver,
+      });
+    });
+  });
+  return map;
+}
+
+function renderChampionCard() {
+  const champion = state.standings[0];
+  if (!champion) {
+    elements.championCard.textContent = 'No data available';
+    return;
+  }
+
+  const runnerUp = state.standings[1];
+  const gapToSecond = runnerUp ? champion.points - runnerUp.points : 0;
+
+  elements.championCard.innerHTML = `
+    <h2>World Champion</h2>
+    <strong>${champion.driver}</strong>
+    <span>${champion.team}</span>
+    <div class="meta">
+      <span>${champion.points} pts</span>
+      <span>${champion.wins} wins</span>
+      <span>${champion.podiums} podiums</span>
+    </div>
+    <p>Fastest laps: ${champion.fastestLaps} • Final margin: ${gapToSecond} pts</p>
+  `;
+}
+
+function renderStandings() {
+  const body = elements.standingsBody;
+  const leaderPoints = state.standings[0]?.points ?? 0;
+  body.innerHTML = '';
+
+  state.standings.forEach((entry, index) => {
+    const row = document.createElement('tr');
+    if (entry.driver === state.selectedDriver) {
+      row.classList.add('highlight');
+    }
+
+    const gap = index === 0 ? '—' : `+${leaderPoints - entry.points}`;
+
+    row.innerHTML = `
+      <td>${index + 1}</td>
+      <td>${entry.driver}</td>
+      <td>${entry.team}</td>
+      <td>${entry.points}</td>
+      <td>${gap}</td>
+      <td>${entry.wins}</td>
+      <td>${entry.podiums}</td>
+      <td>${entry.fastestLaps}</td>
+      <td>P${entry.averageFinish}</td>
+    `;
+
+    body.appendChild(row);
+  });
+}
+
+function populateDriverSelect() {
+  const select = elements.driverSelect;
+  select.innerHTML = '';
+
+  state.standings.forEach((entry, index) => {
+    const option = document.createElement('option');
+    option.value = entry.driver;
+    option.textContent = `#${index + 1} ${entry.driver}`;
+    if (entry.driver === state.selectedDriver) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+}
+
+function setupChart() {
+  const ctx = elements.chartCanvas.getContext('2d');
+  const datasets = state.standings.map((entry) => buildDataset(entry));
+
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: raceLabels,
+      datasets,
+    },
+    options: {
+      maintainAspectRatio: false,
+      responsive: true,
+      interaction: {
+        intersect: false,
+        mode: 'index',
+      },
+      plugins: {
+        legend: {
+          labels: {
+            color: '#e2e8f0',
+            usePointStyle: true,
+            font: {
+              family: 'Barlow',
+              size: 12,
+            },
+          },
+        },
+        tooltip: {
+          callbacks: {
+            title: (items) => {
+              if (!items.length) return '';
+              const index = items[0].dataIndex;
+              const race = state.races[index];
+              return `Round ${race.round} • ${race.name}`;
+            },
+            label: (context) => {
+              const race = state.races[context.dataIndex];
+              return `${context.dataset.label}: ${context.formattedValue} pts after ${race.name}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: '#cbd5f5',
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.15)',
+          },
+        },
+        y: {
+          ticks: {
+            color: '#cbd5f5',
+          },
+          beginAtZero: true,
+          grid: {
+            color: 'rgba(148, 163, 184, 0.15)',
+          },
+        },
+      },
+    },
+  });
+}
+
+function buildDataset(entry) {
+  const baseColor = driverColors[entry.driver] || '#94a3b8';
+  const isSelected = entry.driver === state.selectedDriver;
+  return {
+    label: entry.driver,
+    data: entry.progression,
+    borderColor: baseColor,
+    backgroundColor: hexToRgba(baseColor, isSelected ? 0.25 : 0.1),
+    borderWidth: isSelected ? 3 : 1.5,
+    pointRadius: isSelected ? 4 : 2,
+    pointHoverRadius: 5,
+    tension: 0.28,
+    fill: false,
+    hidden: !state.showAllDrivers && !isSelected,
+  };
+}
+
+function updateChartAppearance() {
+  chart.data.datasets.forEach((dataset) => {
+    const baseColor = driverColors[dataset.label] || '#94a3b8';
+    const isSelected = dataset.label === state.selectedDriver;
+    dataset.hidden = !state.showAllDrivers && !isSelected;
+    dataset.borderWidth = isSelected ? 3 : 1.5;
+    dataset.pointRadius = isSelected ? 4 : state.showAllDrivers ? 2 : 0;
+    dataset.backgroundColor = hexToRgba(baseColor, isSelected ? 0.28 : 0.08);
+    dataset.borderColor = baseColor;
+  });
+  chart.update();
+}
+
+function renderDriverInsight() {
+  const insight = elements.driverInsight;
+  const entry = state.standings.find((driver) => driver.driver === state.selectedDriver);
+  if (!entry) {
+    insight.textContent = 'Select a driver to see season insights.';
+    return;
+  }
+
+  const history = state.driverHistory[state.selectedDriver] || [];
+  if (!history.length) {
+    insight.textContent = 'No race history available.';
+    return;
+  }
+
+  const bestFinish = [...history].sort((a, b) => a.position - b.position)[0];
+  const highestScore = [...history].sort((a, b) => b.points - a.points)[0];
+  const latestRace = history[history.length - 1];
+  const topFiveCount = history.filter((race) => race.position <= 5).length;
+
+  insight.innerHTML = `
+    <h3>${entry.driver}</h3>
+    <p>${entry.team} • ${entry.points} pts • ${entry.wins} wins • ${entry.podiums} podiums • ${entry.fastestLaps} fastest laps</p>
+    <ul>
+      <li>Best finish: P${bestFinish.position} at ${bestFinish.race}</li>
+      <li>Highest scoring weekend: ${highestScore.points} pts at ${highestScore.race}</li>
+      <li>Top-five finishes: ${topFiveCount} of ${history.length}</li>
+      <li>Wrapped the year with P${latestRace.position} in ${latestRace.race}</li>
+    </ul>
+  `;
+}
+
+function renderTimeline() {
+  const container = elements.timeline;
+  container.innerHTML = '';
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  state.races.forEach((race) => {
+    const card = document.createElement('article');
+    card.className = 'race-card';
+
+    const podium = race.results.slice(0, 3);
+    const podiumList = podium
+      .map((entry, index) => {
+        const badges = ['gold', 'silver', 'bronze'];
+        return `
+          <li>
+            <span class="podium-badge ${badges[index]}">${index + 1}</span>
+            <span>${entry.driver}</span>
+          </li>
+        `;
+      })
+      .join('');
+
+    card.innerHTML = `
+      <header>
+        <span class="round-pill">Round ${race.round}</span>
+        <h3>${race.name}</h3>
+        <p class="race-meta">${formatter.format(new Date(race.date))} • ${race.location}</p>
+      </header>
+      <ul class="podium-list">${podiumList}</ul>
+      <p class="fastest-lap">Fastest lap: ${race.fastestLap.driver} (+${race.fastestLap.pointsAwarded} pt)</p>
+      <p>${race.summary}</p>
+    `;
+
+    container.appendChild(card);
+  });
+}
+
+function populateFilters() {
+  const raceFilter = elements.raceFilter;
+  const driverFilter = elements.driverFilter;
+
+  raceFilter.innerHTML = '';
+  const allOption = document.createElement('option');
+  allOption.value = 'all';
+  allOption.textContent = 'All races';
+  raceFilter.appendChild(allOption);
+
+  state.races.forEach((race) => {
+    const option = document.createElement('option');
+    option.value = String(race.round);
+    option.textContent = `Round ${race.round} · ${race.name}`;
+    raceFilter.appendChild(option);
+  });
+  raceFilter.value = 'all';
+
+  driverFilter.innerHTML = '';
+  const allDrivers = document.createElement('option');
+  allDrivers.value = 'all';
+  allDrivers.textContent = 'All drivers';
+  driverFilter.appendChild(allDrivers);
+
+  state.standings.forEach((entry) => {
+    const option = document.createElement('option');
+    option.value = entry.driver;
+    option.textContent = entry.driver;
+    driverFilter.appendChild(option);
+  });
+  driverFilter.value = 'all';
+}
+
+function updateResultsTable() {
+  const raceValue = elements.raceFilter.value;
+  const driverValue = elements.driverFilter.value;
+
+  const rows = [];
+  const relevantRaces = raceValue === 'all'
+    ? state.races
+    : state.races.filter((race) => String(race.round) === raceValue);
+
+  relevantRaces.forEach((race) => {
+    race.results.forEach((result) => {
+      if (driverValue !== 'all' && result.driver !== driverValue) {
+        return;
+      }
+      rows.push({
+        round: race.round,
+        race: race.name,
+        driver: result.driver,
+        team: result.team,
+        position: result.position,
+        points: result.points,
+        fastest: race.fastestLap.driver === result.driver,
+      });
+    });
+  });
+
+  rows.sort((a, b) => (a.round === b.round ? a.position - b.position : a.round - b.round));
+
+  const body = elements.resultsBody;
+  body.innerHTML = '';
+
+  if (!rows.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 7;
+    cell.textContent = 'No results match the current filters.';
+    row.appendChild(cell);
+    body.appendChild(row);
+    return;
+  }
+
+  rows.forEach((rowData) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>R${String(rowData.round).padStart(2, '0')}</td>
+      <td>${rowData.race}</td>
+      <td>P${rowData.position}</td>
+      <td>${rowData.driver}</td>
+      <td>${rowData.team}</td>
+      <td>${rowData.points}</td>
+      <td>${rowData.fastest ? 'Yes (+1)' : '—'}</td>
+    `;
+    body.appendChild(row);
+  });
+}
+
+function hexToRgba(hex, alpha = 1) {
+  const sanitized = hex.replace('#', '');
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Formula 1 2025 Championship Points Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"
+      integrity="sha384-yGXIqGXB9nuSUXwxLBzME2YkdE+5EYXPLkZX31lrT7xvFeoJEB6Digw1VE3Dybvt"
+      crossorigin="anonymous"
+    ></script>
+    <script type="module" src="app.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="header-content">
+        <h1>Formula 1 2025 Championship Points Tracker</h1>
+        <p>
+          Dive into a fictionalised look at the 2025 Formula 1 World Championship.
+          Explore how the points picture evolves over every round, compare the top
+          contenders, and relive the decisive weekends that shaped the season.
+        </p>
+      </div>
+      <div class="champion-card" id="championCard" aria-live="polite"></div>
+    </header>
+
+    <main>
+      <section class="leaderboard-section">
+        <div class="section-header">
+          <h2>Driver Standings</h2>
+          <p>
+            Final classification after 24 rounds including wins, podiums, fastest
+            laps and average finishing position.
+          </p>
+        </div>
+        <div class="table-wrapper">
+          <table id="standingsTable">
+            <thead>
+              <tr>
+                <th scope="col">Pos</th>
+                <th scope="col">Driver</th>
+                <th scope="col">Team</th>
+                <th scope="col">Points</th>
+                <th scope="col">Gap</th>
+                <th scope="col">Wins</th>
+                <th scope="col">Podiums</th>
+                <th scope="col">Fastest laps</th>
+                <th scope="col">Avg finish</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="chart-section">
+        <div class="section-header">
+          <h2>Points Progression</h2>
+          <p>
+            Visualise the momentum swings of the title race. Highlight a driver to
+            focus their line or show the full field for comparison.
+          </p>
+        </div>
+        <div class="chart-controls">
+          <label for="driverSelect">Highlight driver</label>
+          <select id="driverSelect" aria-label="Select driver to highlight"></select>
+          <label class="toggle">
+            <input type="checkbox" id="showAllDrivers" checked />
+            <span>Show all drivers</span>
+          </label>
+        </div>
+        <div class="chart-wrapper">
+          <canvas
+            id="progressChart"
+            role="img"
+            aria-label="Cumulative championship points by race"
+          ></canvas>
+        </div>
+        <div id="driverInsight" class="driver-insight" aria-live="polite"></div>
+      </section>
+
+      <section class="timeline-section">
+        <div class="section-header">
+          <h2>Race Timeline</h2>
+          <p>
+            Key storylines for every Grand Prix including podium finishers and the
+            fastest lap bonus.
+          </p>
+        </div>
+        <div id="raceTimeline" class="timeline-grid"></div>
+      </section>
+
+      <section class="results-section">
+        <div class="section-header">
+          <h2>Race Results Explorer</h2>
+          <p>Filter the classification to inspect how each point was earned.</p>
+        </div>
+        <div class="filters">
+          <label for="raceFilter">Race
+            <select id="raceFilter" aria-label="Filter by race"></select>
+          </label>
+          <label for="driverFilter">Driver
+            <select id="driverFilter" aria-label="Filter by driver"></select>
+          </label>
+        </div>
+        <div class="table-wrapper">
+          <table id="resultsTable">
+            <thead>
+              <tr>
+                <th scope="col">Rnd</th>
+                <th scope="col">Race</th>
+                <th scope="col">Pos</th>
+                <th scope="col">Driver</th>
+                <th scope="col">Team</th>
+                <th scope="col">Points</th>
+                <th scope="col">Fastest lap</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        All numbers are a narrative projection created for this demo application and
+        do not represent real-world 2025 championship data.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/seasonData.js
+++ b/seasonData.js
@@ -1,0 +1,2656 @@
+export const seasonData = {
+  "races": [
+    {
+      "round": 1,
+      "name": "Bahrain Grand Prix",
+      "date": "2025-03-16",
+      "circuit": "Bahrain International Circuit",
+      "location": "Sakhir, Bahrain",
+      "laps": 57,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 19
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Charles Leclerc, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 2,
+      "name": "Saudi Arabian Grand Prix",
+      "date": "2025-03-30",
+      "circuit": "Jeddah Corniche Circuit",
+      "location": "Jeddah, Saudi Arabia",
+      "laps": 50,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 19
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lando Norris headed home Max Verstappen and Charles Leclerc, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 3,
+      "name": "Australian Grand Prix",
+      "date": "2025-04-13",
+      "circuit": "Albert Park Circuit",
+      "location": "Melbourne, Australia",
+      "laps": 58,
+      "fastestLap": {
+        "driver": "Oscar Piastri",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Oscar Piastri headed home Carlos Sainz and Lando Norris, with Oscar Piastri claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 4,
+      "name": "Japanese Grand Prix",
+      "date": "2025-04-27",
+      "circuit": "Suzuka International Racing Course",
+      "location": "Suzuka, Japan",
+      "laps": 53,
+      "fastestLap": {
+        "driver": "Charles Leclerc",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Charles Leclerc headed home Max Verstappen and Lando Norris, with Charles Leclerc claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 5,
+      "name": "Chinese Grand Prix",
+      "date": "2025-05-11",
+      "circuit": "Shanghai International Circuit",
+      "location": "Shanghai, China",
+      "laps": 56,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Lewis Hamilton, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 6,
+      "name": "Miami Grand Prix",
+      "date": "2025-05-18",
+      "circuit": "Miami International Autodrome",
+      "location": "Miami, United States",
+      "laps": 57,
+      "fastestLap": {
+        "driver": "Charles Leclerc",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Charles Leclerc headed home Max Verstappen and Carlos Sainz, with Charles Leclerc claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 7,
+      "name": "Emilia Romagna Grand Prix",
+      "date": "2025-05-25",
+      "circuit": "Autodromo Enzo e Dino Ferrari",
+      "location": "Imola, Italy",
+      "laps": 63,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Carlos Sainz and Charles Leclerc, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 8,
+      "name": "Monaco Grand Prix",
+      "date": "2025-06-01",
+      "circuit": "Circuit de Monaco",
+      "location": "Monte Carlo, Monaco",
+      "laps": 78,
+      "fastestLap": {
+        "driver": "Oscar Piastri",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 16
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Charles Leclerc headed home Fernando Alonso and Oscar Piastri, with Oscar Piastri claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 9,
+      "name": "Canadian Grand Prix",
+      "date": "2025-06-15",
+      "circuit": "Circuit Gilles Villeneuve",
+      "location": "Montreal, Canada",
+      "laps": 70,
+      "fastestLap": {
+        "driver": "Lewis Hamilton",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lewis Hamilton headed home Max Verstappen and George Russell, with Lewis Hamilton claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 10,
+      "name": "Spanish Grand Prix",
+      "date": "2025-06-29",
+      "circuit": "Circuit de Barcelona-Catalunya",
+      "location": "Montmel\u00f3, Spain",
+      "laps": 66,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Carlos Sainz and Lando Norris, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 11,
+      "name": "Austrian Grand Prix",
+      "date": "2025-07-06",
+      "circuit": "Red Bull Ring",
+      "location": "Spielberg, Austria",
+      "laps": 71,
+      "fastestLap": {
+        "driver": "Charles Leclerc",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 13
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and George Russell, with Charles Leclerc claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 12,
+      "name": "British Grand Prix",
+      "date": "2025-07-13",
+      "circuit": "Silverstone Circuit",
+      "location": "Silverstone, United Kingdom",
+      "laps": 52,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 19
+        },
+        {
+          "position": 3,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lewis Hamilton headed home Lando Norris and George Russell, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 13,
+      "name": "Hungarian Grand Prix",
+      "date": "2025-07-27",
+      "circuit": "Hungaroring",
+      "location": "Mogyor\u00f3d, Hungary",
+      "laps": 70,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Charles Leclerc and Lando Norris, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 14,
+      "name": "Belgian Grand Prix",
+      "date": "2025-08-03",
+      "circuit": "Circuit de Spa-Francorchamps",
+      "location": "Stavelot, Belgium",
+      "laps": 44,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lando Norris headed home Max Verstappen and Oscar Piastri, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 15,
+      "name": "Dutch Grand Prix",
+      "date": "2025-08-24",
+      "circuit": "Circuit Zandvoort",
+      "location": "Zandvoort, Netherlands",
+      "laps": 72,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Charles Leclerc, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 16,
+      "name": "Italian Grand Prix",
+      "date": "2025-09-07",
+      "circuit": "Autodromo Nazionale Monza",
+      "location": "Monza, Italy",
+      "laps": 53,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 19
+        },
+        {
+          "position": 3,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Charles Leclerc headed home Lando Norris and Carlos Sainz, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 17,
+      "name": "Azerbaijan Grand Prix",
+      "date": "2025-09-21",
+      "circuit": "Baku City Circuit",
+      "location": "Baku, Azerbaijan",
+      "laps": 51,
+      "fastestLap": {
+        "driver": "Charles Leclerc",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 16
+        },
+        {
+          "position": 4,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lando Norris headed home Max Verstappen and Charles Leclerc, with Charles Leclerc claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 18,
+      "name": "Singapore Grand Prix",
+      "date": "2025-09-28",
+      "circuit": "Marina Bay Street Circuit",
+      "location": "Singapore",
+      "laps": 62,
+      "fastestLap": {
+        "driver": "Charles Leclerc",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Charles Leclerc headed home Lando Norris and Lewis Hamilton, with Charles Leclerc claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 19,
+      "name": "United States Grand Prix",
+      "date": "2025-10-19",
+      "circuit": "Circuit of the Americas",
+      "location": "Austin, United States",
+      "laps": 56,
+      "fastestLap": {
+        "driver": "Lewis Hamilton",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lewis Hamilton headed home Lando Norris and Max Verstappen, with Lewis Hamilton claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 20,
+      "name": "Mexico City Grand Prix",
+      "date": "2025-10-26",
+      "circuit": "Aut\u00f3dromo Hermanos Rodr\u00edguez",
+      "location": "Mexico City, Mexico",
+      "laps": 71,
+      "fastestLap": {
+        "driver": "Sergio Perez",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Sergio Perez headed home Max Verstappen and Lando Norris, with Sergio Perez claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 21,
+      "name": "S\u00e3o Paulo Grand Prix",
+      "date": "2025-11-09",
+      "circuit": "Aut\u00f3dromo Jos\u00e9 Carlos Pace",
+      "location": "S\u00e3o Paulo, Brazil",
+      "laps": 71,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Charles Leclerc, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 22,
+      "name": "Las Vegas Grand Prix",
+      "date": "2025-11-22",
+      "circuit": "Las Vegas Strip Circuit",
+      "location": "Las Vegas, United States",
+      "laps": 50,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 25
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 19
+        },
+        {
+          "position": 3,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Lewis Hamilton, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 23,
+      "name": "Qatar Grand Prix",
+      "date": "2025-11-30",
+      "circuit": "Lusail International Circuit",
+      "location": "Lusail, Qatar",
+      "laps": 57,
+      "fastestLap": {
+        "driver": "Lando Norris",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Lando Norris headed home Max Verstappen and Oscar Piastri, with Lando Norris claiming the fastest lap to add more drama to the title fight."
+    },
+    {
+      "round": 24,
+      "name": "Abu Dhabi Grand Prix",
+      "date": "2025-12-07",
+      "circuit": "Yas Marina Circuit",
+      "location": "Abu Dhabi, UAE",
+      "laps": 58,
+      "fastestLap": {
+        "driver": "Max Verstappen",
+        "pointsAwarded": 1
+      },
+      "results": [
+        {
+          "position": 1,
+          "driver": "Max Verstappen",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 26
+        },
+        {
+          "position": 2,
+          "driver": "Lando Norris",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 18
+        },
+        {
+          "position": 3,
+          "driver": "Charles Leclerc",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 15
+        },
+        {
+          "position": 4,
+          "driver": "Carlos Sainz",
+          "team": "Ferrari",
+          "status": "Finished",
+          "points": 12
+        },
+        {
+          "position": 5,
+          "driver": "Oscar Piastri",
+          "team": "McLaren",
+          "status": "Finished",
+          "points": 10
+        },
+        {
+          "position": 6,
+          "driver": "Lewis Hamilton",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 8
+        },
+        {
+          "position": 7,
+          "driver": "George Russell",
+          "team": "Mercedes",
+          "status": "Finished",
+          "points": 6
+        },
+        {
+          "position": 8,
+          "driver": "Fernando Alonso",
+          "team": "Aston Martin",
+          "status": "Finished",
+          "points": 4
+        },
+        {
+          "position": 9,
+          "driver": "Sergio Perez",
+          "team": "Red Bull Racing",
+          "status": "Finished",
+          "points": 2
+        },
+        {
+          "position": 10,
+          "driver": "Alex Albon",
+          "team": "Williams",
+          "status": "Finished",
+          "points": 1
+        }
+      ],
+      "summary": "Max Verstappen headed home Lando Norris and Charles Leclerc, with Max Verstappen claiming the fastest lap to add more drama to the title fight."
+    }
+  ],
+  "standings": [
+    {
+      "driver": "Max Verstappen",
+      "team": "Red Bull Racing",
+      "points": 461,
+      "wins": 10,
+      "podiums": 19,
+      "fastestLaps": 8,
+      "averageFinish": 2.38,
+      "progression": [
+        25,
+        44,
+        56,
+        74,
+        100,
+        118,
+        144,
+        150,
+        168,
+        194,
+        219,
+        225,
+        251,
+        269,
+        295,
+        307,
+        325,
+        333,
+        348,
+        366,
+        392,
+        417,
+        435,
+        461
+      ],
+      "racePoints": [
+        25,
+        19,
+        12,
+        18,
+        26,
+        18,
+        26,
+        6,
+        18,
+        26,
+        25,
+        6,
+        26,
+        18,
+        26,
+        12,
+        18,
+        8,
+        15,
+        18,
+        26,
+        25,
+        18,
+        26
+      ]
+    },
+    {
+      "driver": "Lando Norris",
+      "team": "McLaren",
+      "points": 425,
+      "wins": 4,
+      "podiums": 20,
+      "fastestLaps": 6,
+      "averageFinish": 2.42,
+      "progression": [
+        19,
+        44,
+        59,
+        74,
+        92,
+        104,
+        116,
+        126,
+        138,
+        153,
+        171,
+        190,
+        205,
+        231,
+        249,
+        268,
+        293,
+        311,
+        329,
+        344,
+        362,
+        381,
+        407,
+        425
+      ],
+      "racePoints": [
+        19,
+        25,
+        15,
+        15,
+        18,
+        12,
+        12,
+        10,
+        12,
+        15,
+        18,
+        19,
+        15,
+        26,
+        18,
+        19,
+        25,
+        18,
+        18,
+        15,
+        18,
+        19,
+        26,
+        18
+      ]
+    },
+    {
+      "driver": "Charles Leclerc",
+      "team": "Ferrari",
+      "points": 377,
+      "wins": 5,
+      "podiums": 13,
+      "fastestLaps": 5,
+      "averageFinish": 3.17,
+      "progression": [
+        15,
+        30,
+        40,
+        66,
+        78,
+        104,
+        119,
+        144,
+        154,
+        164,
+        177,
+        189,
+        207,
+        219,
+        234,
+        259,
+        275,
+        301,
+        311,
+        323,
+        338,
+        350,
+        362,
+        377
+      ],
+      "racePoints": [
+        15,
+        15,
+        10,
+        26,
+        12,
+        26,
+        15,
+        25,
+        10,
+        10,
+        13,
+        12,
+        18,
+        12,
+        15,
+        25,
+        16,
+        26,
+        10,
+        12,
+        15,
+        12,
+        12,
+        15
+      ]
+    },
+    {
+      "driver": "Lewis Hamilton",
+      "team": "Mercedes",
+      "points": 286,
+      "wins": 3,
+      "podiums": 6,
+      "fastestLaps": 2,
+      "averageFinish": 4.58,
+      "progression": [
+        10,
+        20,
+        28,
+        40,
+        55,
+        65,
+        75,
+        83,
+        109,
+        117,
+        125,
+        150,
+        160,
+        168,
+        176,
+        186,
+        196,
+        211,
+        237,
+        245,
+        255,
+        270,
+        278,
+        286
+      ],
+      "racePoints": [
+        10,
+        10,
+        8,
+        12,
+        15,
+        10,
+        10,
+        8,
+        26,
+        8,
+        8,
+        25,
+        10,
+        8,
+        8,
+        10,
+        10,
+        15,
+        26,
+        8,
+        10,
+        15,
+        8,
+        8
+      ]
+    },
+    {
+      "driver": "Carlos Sainz",
+      "team": "Ferrari",
+      "points": 250,
+      "wins": 0,
+      "podiums": 5,
+      "fastestLaps": 0,
+      "averageFinish": 4.96,
+      "progression": [
+        12,
+        24,
+        42,
+        50,
+        56,
+        71,
+        89,
+        101,
+        107,
+        125,
+        131,
+        139,
+        151,
+        157,
+        169,
+        184,
+        190,
+        196,
+        202,
+        212,
+        224,
+        232,
+        238,
+        250
+      ],
+      "racePoints": [
+        12,
+        12,
+        18,
+        8,
+        6,
+        15,
+        18,
+        12,
+        6,
+        18,
+        6,
+        8,
+        12,
+        6,
+        12,
+        15,
+        6,
+        6,
+        6,
+        10,
+        12,
+        8,
+        6,
+        12
+      ]
+    },
+    {
+      "driver": "Oscar Piastri",
+      "team": "McLaren",
+      "points": 248,
+      "wins": 1,
+      "podiums": 4,
+      "fastestLaps": 2,
+      "averageFinish": 5.08,
+      "progression": [
+        8,
+        16,
+        42,
+        52,
+        60,
+        66,
+        74,
+        90,
+        98,
+        110,
+        120,
+        130,
+        138,
+        153,
+        163,
+        171,
+        179,
+        191,
+        199,
+        205,
+        213,
+        223,
+        238,
+        248
+      ],
+      "racePoints": [
+        8,
+        8,
+        26,
+        10,
+        8,
+        6,
+        8,
+        16,
+        8,
+        12,
+        10,
+        10,
+        8,
+        15,
+        10,
+        8,
+        8,
+        12,
+        8,
+        6,
+        8,
+        10,
+        15,
+        10
+      ]
+    },
+    {
+      "driver": "George Russell",
+      "team": "Mercedes",
+      "points": 197,
+      "wins": 0,
+      "podiums": 3,
+      "fastestLaps": 0,
+      "averageFinish": 5.96,
+      "progression": [
+        6,
+        12,
+        18,
+        24,
+        34,
+        42,
+        48,
+        52,
+        67,
+        73,
+        88,
+        103,
+        109,
+        119,
+        125,
+        131,
+        143,
+        153,
+        165,
+        169,
+        175,
+        181,
+        191,
+        197
+      ],
+      "racePoints": [
+        6,
+        6,
+        6,
+        6,
+        10,
+        8,
+        6,
+        4,
+        15,
+        6,
+        15,
+        15,
+        6,
+        10,
+        6,
+        6,
+        12,
+        10,
+        12,
+        4,
+        6,
+        6,
+        10,
+        6
+      ]
+    },
+    {
+      "driver": "Sergio Perez",
+      "team": "Red Bull Racing",
+      "points": 92,
+      "wins": 1,
+      "podiums": 1,
+      "fastestLaps": 1,
+      "averageFinish": 8.25,
+      "progression": [
+        4,
+        6,
+        10,
+        12,
+        16,
+        20,
+        22,
+        24,
+        28,
+        30,
+        34,
+        36,
+        40,
+        44,
+        46,
+        48,
+        50,
+        52,
+        54,
+        80,
+        82,
+        86,
+        90,
+        92
+      ],
+      "racePoints": [
+        4,
+        2,
+        4,
+        2,
+        4,
+        4,
+        2,
+        2,
+        4,
+        2,
+        4,
+        2,
+        4,
+        4,
+        2,
+        2,
+        2,
+        2,
+        2,
+        26,
+        2,
+        4,
+        4,
+        2
+      ]
+    },
+    {
+      "driver": "Fernando Alonso",
+      "team": "Aston Martin",
+      "points": 88,
+      "wins": 0,
+      "podiums": 1,
+      "fastestLaps": 0,
+      "averageFinish": 8.21,
+      "progression": [
+        2,
+        6,
+        8,
+        12,
+        14,
+        16,
+        20,
+        38,
+        40,
+        44,
+        46,
+        50,
+        52,
+        54,
+        58,
+        62,
+        66,
+        70,
+        74,
+        76,
+        80,
+        82,
+        84,
+        88
+      ],
+      "racePoints": [
+        2,
+        4,
+        2,
+        4,
+        2,
+        2,
+        4,
+        18,
+        2,
+        4,
+        2,
+        4,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        4,
+        2,
+        4,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "driver": "Alex Albon",
+      "team": "Williams",
+      "points": 24,
+      "wins": 0,
+      "podiums": 0,
+      "fastestLaps": 0,
+      "averageFinish": 10.0,
+      "progression": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24
+      ],
+      "racePoints": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    }
+  ]
+};

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,456 @@
+:root {
+  --background: radial-gradient(circle at top left, #1b1f3b, #0b0d17 55%);
+  --surface: rgba(17, 24, 39, 0.85);
+  --surface-alt: rgba(31, 41, 55, 0.65);
+  --border: rgba(148, 163, 184, 0.2);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --accent: #ff4655;
+  --accent-soft: rgba(255, 70, 85, 0.1);
+  --highlight: #f59e0b;
+  --shadow: 0 22px 40px rgba(15, 23, 42, 0.45);
+  --font-family: "Barlow", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  font-family: var(--font-family);
+  background: var(--background);
+  color: var(--text-primary);
+}
+
+body {
+  line-height: 1.6;
+}
+
+main {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  padding-bottom: 4rem;
+}
+
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 2rem;
+  width: min(1100px, 92vw);
+  margin: 4rem auto 3rem;
+  padding: 2.5rem;
+  background: linear-gradient(130deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.75));
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  box-shadow: var(--shadow);
+}
+
+.header-content {
+  flex: 1 1 320px;
+}
+
+.header-content h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.2rem, 2.8vw + 1rem, 3.1rem);
+  line-height: 1.2;
+}
+
+.header-content p {
+  margin: 0;
+  color: var(--text-secondary);
+  max-width: 32rem;
+}
+
+.champion-card {
+  flex: 1 1 260px;
+  background: linear-gradient(135deg, rgba(255, 70, 85, 0.9), rgba(245, 158, 11, 0.9));
+  border-radius: 22px;
+  padding: 2rem;
+  color: #0b0d17;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+  box-shadow: 0 18px 40px rgba(255, 70, 85, 0.35);
+  min-height: 220px;
+}
+
+.champion-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.champion-card strong {
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.champion-card .meta {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.9rem;
+}
+
+.section-header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  max-width: 50ch;
+}
+
+.table-wrapper {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  padding: 0.5rem;
+  overflow: hidden;
+}
+
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-wrapper thead {
+  background: rgba(15, 23, 42, 0.6);
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(6px);
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  font-size: 0.95rem;
+}
+
+.table-wrapper tbody tr:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.table-wrapper tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.03);
+}
+
+.table-wrapper tbody tr:nth-child(even):hover {
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.table-wrapper tbody tr.highlight {
+  background: rgba(255, 70, 85, 0.12);
+}
+
+.table-wrapper tbody tr.highlight:hover {
+  background: rgba(255, 70, 85, 0.18);
+}
+
+.table-wrapper td:first-child,
+.table-wrapper th:first-child {
+  width: 4rem;
+  font-weight: 600;
+}
+
+.table-wrapper td:nth-child(2),
+.table-wrapper th:nth-child(2) {
+  width: 9rem;
+}
+
+.table-wrapper td:nth-child(3) {
+  font-weight: 600;
+}
+
+.table-wrapper td:last-child {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.chart-section,
+.timeline-section,
+.results-section,
+.leaderboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chart-controls {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.chart-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.chart-controls select {
+  background: var(--surface-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.5rem 0.9rem;
+  font-size: 1rem;
+  min-width: 180px;
+}
+
+.chart-controls select:focus {
+  outline: 2px solid var(--highlight);
+  outline-offset: 2px;
+}
+
+.chart-controls .toggle input {
+  accent-color: var(--highlight);
+}
+
+.chart-wrapper {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  min-height: 360px;
+}
+
+.chart-wrapper canvas {
+  width: 100% !important;
+  height: 320px !important;
+}
+
+.driver-insight {
+  background: var(--surface-alt);
+  border-radius: 18px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.12);
+}
+
+.driver-insight h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.35rem;
+}
+
+.driver-insight p {
+  margin: 0.25rem 0 0.75rem;
+  color: var(--text-secondary);
+}
+
+.driver-insight ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.driver-insight li {
+  position: relative;
+  padding-left: 1.2rem;
+}
+
+.driver-insight li::before {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--highlight);
+  position: absolute;
+  left: 0;
+  top: 0.45rem;
+}
+
+.timeline-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.race-card {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.race-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, transparent, rgba(255, 70, 85, 0.08));
+  pointer-events: none;
+}
+
+.race-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.round-pill {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.race-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.race-meta {
+  color: var(--text-secondary);
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.podium-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.podium-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.podium-badge {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.podium-badge.gold {
+  background: rgba(255, 215, 0, 0.18);
+  color: #ffe27a;
+}
+
+.podium-badge.silver {
+  background: rgba(209, 213, 219, 0.2);
+  color: #e5e7eb;
+}
+
+.podium-badge.bronze {
+  background: rgba(205, 127, 50, 0.2);
+  color: #f2c57c;
+}
+
+.fastest-lap {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.filters {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.filters select {
+  background: var(--surface-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.55rem 0.9rem;
+  font-size: 1rem;
+  min-width: 200px;
+}
+
+.filters select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.site-footer {
+  margin: 2rem auto 4rem;
+  width: min(1100px, 92vw);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 820px) {
+  .site-header {
+    flex-direction: column;
+    padding: 2rem;
+  }
+
+  .champion-card {
+    min-height: 0;
+  }
+
+  .chart-wrapper canvas {
+    height: 280px !important;
+  }
+
+  .table-wrapper th,
+  .table-wrapper td {
+    padding: 0.7rem 0.75rem;
+  }
+}
+
+@media (max-width: 540px) {
+  main {
+    gap: 2.5rem;
+  }
+
+  .chart-controls {
+    align-items: flex-start;
+  }
+
+  .filters select {
+    min-width: 160px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a static single-page app to visualise a fictional 2025 Formula 1 season
- add interactive standings, points progression chart, race timeline and results explorer
- provide local season dataset and refreshed documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a5a4fc188332b029368b726f8698